### PR TITLE
Selector and URL updates, inc disabling on 1 character fields

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -33,7 +33,7 @@ vex.dialog.buttons.YES.text = "I Understand";
  * Globals
  */
 var PASS_PROTECT_EMAIL_CHECK_URI = "https://haveibeenpwned.com/api/v2/breachedaccount/";
-var PASS_PROTECT_PASTE_CHECK_URI = "https://haveibeenpwned.com/api/v2/pasteaccountaccount/";
+var PASS_PROTECT_PASTE_CHECK_URI = "https://haveibeenpwned.com/api/v2/pasteaccount/";
 var PASS_PROTECT_PASSWORD_CHECK_URI = "https://api.pwnedpasswords.com/range/";
 
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -100,7 +100,7 @@ function protectInputs() {
     'input[type="text"][id*="email"i], ' +
     'input[type="text"][placeholder*="email"i], ' +
     'input[type="email"], ' +
-    'input[type="password"]'
+    'input[type="password"]:not([maxlength="1"])'
   );
 
   for (var i = 0; i < inputs.length; i++) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -95,10 +95,17 @@ function isIgnored(sensitiveData) {
  * changes.
  */
 function protectInputs() {
-  var inputs = document.getElementsByTagName("input");
+  var inputs = document.querySelectorAll(
+    'input[type="text"][name*="email"i], ' +
+    'input[type="text"][id*="email"i], ' +
+    'input[type="text"][placeholder*="email"i], ' +
+    'input[type="email"], ' +
+    'input[type="password"]'
+  );
 
   for (var i = 0; i < inputs.length; i++) {
     switch (inputs[i].type) {
+      case "text":
       case "email":
         //inputs[i].addEventListener("change", protectEmailInput);
         break;
@@ -107,21 +114,6 @@ function protectInputs() {
         break;
     }
   }
-
-  //inputs = document.querySelectorAll("input[type='text']");
-  //for (var i = 0; i < inputs.length; i++) {
-  //  if (inputs[i].name.toLowerCase().indexOf("email") !== -1) {
-  //    return inputs[i].addEventListener("change", protectEmailInput);
-  //  }
-
-  //  if (inputs[i].id.toLowerCase().indexOf("email") !== -1) {
-  //    return inputs[i].addEventListener("change", protectEmailInput);
-  //  }
-
-  //  if (inputs[i].placeholder.toLowerCase().indexOf("email") !== -1) {
-  //    return inputs[i].addEventListener("change", protectEmailInput);
-  //  }
-  //}
 }
 
 


### PR DESCRIPTION
- Changed to using CSS3 selectors to find correct fields, since these have been supported by chrome for quite some time
- Updated password check URL to current URL in the documentation for the v2 api: https://haveibeenpwned.com/API/v2#PastesForAccount
- Removed application on password fields that are max length 1 character. This always produces a false positive, and interferes with usage of Bank websites etc. (e.g. enter 3rd character of your passphrase)